### PR TITLE
fix: always show grid-to-battery flow line when grid charges battery

### DIFF
--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -2444,11 +2444,8 @@
       battChargeRemaining = Math.max(0, battChargeRemaining - solarToBattery);
       solarRemaining = Math.max(0, solarRemaining - solarToBattery);
 
-      let gridToBattery = 0;
-      if (solarToBattery < batteryMin) {
-        gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
-        gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
-      }
+      const gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
+      gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
 
       const solarExport = Math.min(gridExport, solarRemaining);
       const remainingGridExport = Math.max(0, gridExport - solarExport);


### PR DESCRIPTION
## Problem

The grid→battery animation was never shown in cases where solar was also charging the battery above the minimum threshold (`solarToBattery >= batteryMin`).

Root cause: `gridToBattery` was wrapped in `if (solarToBattery < batteryMin)`, which meant:
- If solar covered even a small portion of battery charging (above threshold), grid-to-battery was silently set to 0
- Users with SolarEdge or similar inverters charging battery from grid at night with even a tiny solar contribution would see no grid→battery line

## Fix

Remove the condition and always compute `gridToBattery` from whatever battery charge capacity remains after solar allocation. The existing `_activatePath` call already enforces the minimum-watt guard, so no duplicate filtering is needed.

```js
// Before
let gridToBattery = 0;
if (solarToBattery < batteryMin) {
  gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
  gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
}

// After
const gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
```

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)