### PR TITLE
feat: separate battery/grid entities, smart editor filtering, UI restructure + fix grid→battery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 
 Custom Home Assistant Lovelace card for energy flows on a house scene, with dynamic weather/day-night backgrounds and EV-aware layout switching.
 
-> Recent additions:
+> **Fork notice** — This is a community fork of
+> [stexecute/tesla-style-energy-flow](https://github.com/stexecute/tesla-style-energy-flow)
+> (MIT). The following were contributed by this fork and already merged into upstream:
+> visual scene-position editor, editor debouncing, Tesla-style label hierarchy,
+> scene tone gradients per time-of-day, extended `background_map` keys.
 >
-> - Visual scene-position editor (modal with drag handles for label,
->   value and guide endpoints, per background scene)
-> - Editor debouncing and focus tracking to avoid cursor jumps while
->   typing in the config sidebar
-> - Tesla-style label hierarchy (smaller grey labels, larger white
->   values) with a dedicated charge-direction arrow between the value
->   and percentage row for battery and EV nodes
-> - Scene tone gradients per time-of-day (morning / afternoon /
->   evening / night / storm) layered on top of the existing weather
->   backgrounds
-> - Extended `background_map` keys for the new time-of-day slots
+> This fork currently adds the following on top of upstream (PR #22 open):
+>
+> - **fix:** Grid → Battery flow animation now always shown when the
+>   grid charges the battery (with or without simultaneous solar) *(not fully tested — feedback welcome)*
+> - **feat:** Separate battery charge / discharge power entities —
+>   `battery_charge_power` and `battery_discharge_power`
+> - **feat:** Separate grid import / export power entities —
+>   `grid_import_power` and `grid_export_power` (SMA SHM 2.0, Victron, Fronius, …)
+> - **feat:** Smart entity filtering in editor dropdowns (W/kW, %, V, A)
+> - **refactor:** Fully restructured editor UI — sensors grouped by topic,
+>   visual editor button at the top, friendly names in dropdowns
+>
+> Upstream maintainer: [@stexecute](https://github.com/stexecute).
+> Until PR #22 is merged this fork can be installed as a HACS Custom Repository.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=stexecute&repository=tesla-style-energy-flow&category=dashboard)
 

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -2444,11 +2444,8 @@
       battChargeRemaining = Math.max(0, battChargeRemaining - solarToBattery);
       solarRemaining = Math.max(0, solarRemaining - solarToBattery);
 
-      let gridToBattery = 0;
-      if (solarToBattery < batteryMin) {
-        gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
-        gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
-      }
+      const gridToBattery = Math.min(battChargeRemaining, gridImportRemaining);
+      gridImportRemaining = Math.max(0, gridImportRemaining - gridToBattery);
 
       const solarExport = Math.min(gridExport, solarRemaining);
       const remainingGridExport = Math.max(0, gridExport - solarExport);

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -2717,7 +2717,9 @@
         .concat(
           values.map((id) => {
             const selected = id === current ? ' selected' : '';
-            return `<option value="${this._escapeHtml(id)}"${selected}>${this._escapeHtml(id)}</option>`;
+            const friendlyName = this._hass?.states[id]?.attributes?.friendly_name;
+            const displayText = friendlyName ? `${friendlyName} · ${id}` : id;
+            return `<option value="${this._escapeHtml(id)}"${selected}>${this._escapeHtml(displayText)}</option>`;
           })
         )
         .join('');
@@ -3514,27 +3516,73 @@
           .entity-select {
             font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
           }
+          .group-divider {
+            grid-column: 1 / -1;
+            margin: 4px 0 0 0;
+            border: none;
+            border-top: 1px solid rgba(255,255,255,0.07);
+          }
+          .group-label {
+            grid-column: 1 / -1;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--secondary-text-color);
+            opacity: 0.7;
+            padding-top: 4px;
+          }
+          .note {
+            grid-column: 1 / -1;
+            font-size: 11px;
+            color: var(--secondary-text-color);
+            opacity: 0.6;
+            font-style: italic;
+          }
+          .visual-editor-btn-wrap {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+          }
+          button.visual-editor-btn {
+            padding: 10px 20px;
+            font-size: 13px;
+            font-weight: 600;
+            border-radius: 8px;
+            border: none;
+            background: var(--primary-color, #03a9f4);
+            color: #fff;
+            cursor: pointer;
+            letter-spacing: 0.03em;
+          }
+          button.visual-editor-btn:hover {
+            opacity: 0.88;
+          }
+          details.collapsible {
+            grid-column: 1 / -1;
+          }
+          details.collapsible summary {
+            font-size: 12px;
+            cursor: pointer;
+            color: var(--secondary-text-color);
+            padding: 4px 0;
+            user-select: none;
+          }
+          details.collapsible .grid {
+            margin-top: 8px;
+          }
         </style>
         <div class="wrap">
+
+          <!-- ① General -->
           <div class="block">
             <h4>${this._t('editor.section_general', 'General')}</h4>
             <div class="grid">
               <label>${this._t('editor.field_title', 'Title')}</label>
               <input data-path="title" value="${cfg.title || ''}">
               ${this._languageSelectRow()}
-              <label>${this._t('editor.field_background', 'Background URL')}</label>
-              <input data-path="background" value="${cfg.background || ''}">
-              <label>${this._t('editor.field_background_base', 'Background Assets Base (auto)')}</label>
-              <input data-path="background_asset_base" value="${cfg.background_asset_base || '/local/community/tesla-style-energy-flow/backgrounds'}">
               ${this._powerUnitModeRow()}
-              <div class="row">
-                <label>${this._t('editor.field_grid_invert', 'Invert grid sign')}</label>
-                <input type="checkbox" data-path="grid_invert" ${cfg.grid_invert ? 'checked' : ''}>
-              </div>
-              <div class="row">
-                <label>Invert battery sign</label>
-                <input type="checkbox" data-path="battery_invert" ${cfg.battery_invert ? 'checked' : ''}>
-              </div>
               <div class="row">
                 <label>Show header</label>
                 <input type="checkbox" data-path="show_header" ${cfg.show_header !== false ? 'checked' : ''}>
@@ -3551,14 +3599,126 @@
               <input type="number" step="0.01" data-path="scene_scale" value="${safeNum(cfg.scene_scale, 1)}">
               <label>Font scale</label>
               <input type="number" step="0.05" min="0.75" max="1.35" data-path="font_scale" value="${safeNum(cfg.font_scale, 1)}">
-              <label>EV 1 label</label>
-              <input data-path="ev_label" value="${this._escapeHtml(cfg.ev_label || '')}">
-              <label>EV 2 label</label>
-              <input data-path="ev2_label" value="${this._escapeHtml(cfg.ev2_label || '')}">
-              <label>Roof Array A label</label>
-              <input data-path="roof_a_label" value="${this._escapeHtml(cfg.roof_a_label || 'ARRAY A')}">
-              <label>Roof Array B label</label>
-              <input data-path="roof_b_label" value="${this._escapeHtml(cfg.roof_b_label || 'ARRAY B')}">
+            </div>
+          </div>
+
+          <!-- ② Visual layout editor — prominent, at the top -->
+          <div class="block">
+            <h4>${this._t('editor.section_scene_positions', 'Scene positions')}</h4>
+            <div class="visual-editor-btn-wrap">
+              <button type="button" class="visual-editor-btn position-open-button" data-open-position-editor>${this._t('editor.position_open_button', 'Edit visually')}</button>
+              <span class="hint">${this._t('editor.position_hint', 'Battery percent follows the battery kW value automatically. Path geometry stays in YAML/JSON.')}</span>
+            </div>
+            <details class="collapsible position-json-details" style="margin-top:8px">
+              <summary>scene_component_map JSON</summary>
+              <textarea class="positions-json" data-json-path="scene_component_map" data-commit="change" spellcheck="false">${this._escapeHtml(this._jsonString('scene_component_map'))}</textarea>
+            </details>
+          </div>
+
+          <!-- ③ Solar sensors -->
+          <div class="block">
+            <h4>☀️ Solar</h4>
+            <div class="grid">
+              ${this._entitySelectRow(this._t('editor.sensor_solar', 'Solar Power'), 'entities.solar_power', powerIds('entities.solar_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              <details class="collapsible">
+                <summary>Roof Array A / B (optional)</summary>
+                <div class="grid">
+                  ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', powerIds('entities.roof_a_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                  ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', voltIds('entities.roof_a_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                  ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', ampIds('entities.roof_a_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                  ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', powerIds('entities.roof_b_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                  ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', voltIds('entities.roof_b_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                  ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', ampIds('entities.roof_b_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                </div>
+              </details>
+            </div>
+          </div>
+
+          <!-- ④ Grid sensors -->
+          <div class="block">
+            <h4>⚡ Grid</h4>
+            <div class="grid">
+              <span class="group-label">Combined sensor (+ = import, − = export)</span>
+              ${this._entitySelectRow(this._t('editor.sensor_grid', 'Grid Power'), 'entities.grid_power', powerIds('entities.grid_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${(cfg.entities?.grid_import_power || cfg.entities?.grid_export_power) ? '' : `
+              <div class="row">
+                <label>${this._t('editor.field_grid_invert', 'Invert grid sign')}</label>
+                <input type="checkbox" data-path="grid_invert" ${cfg.grid_invert ? 'checked' : ''}>
+              </div>`}
+              <hr class="group-divider">
+              <span class="group-label">— or — separate sensors (always positive)</span>
+              ${this._entitySelectRow(this._t('editor.sensor_grid_import', 'Grid Import Power'), 'entities.grid_import_power', powerIds('entities.grid_import_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_grid_export', 'Grid Export Power'), 'entities.grid_export_power', powerIds('entities.grid_export_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${(cfg.entities?.grid_import_power || cfg.entities?.grid_export_power) ? `<span class="note">grid_invert not needed when using separate import/export sensors</span>` : ''}
+            </div>
+          </div>
+
+          <!-- ⑤ Battery sensors -->
+          <div class="block">
+            <h4>🔋 Battery</h4>
+            <div class="grid">
+              <span class="group-label">Combined sensor (+ = charging, − = discharging)</span>
+              ${this._entitySelectRow(this._t('editor.sensor_battery', 'Battery Power'), 'entities.battery_power', powerIds('entities.battery_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${(cfg.entities?.battery_charge_power || cfg.entities?.battery_discharge_power) ? '' : `
+              <div class="row">
+                <label>Invert battery sign</label>
+                <input type="checkbox" data-path="battery_invert" ${cfg.battery_invert ? 'checked' : ''}>
+              </div>`}
+              <hr class="group-divider">
+              <span class="group-label">— or — separate sensors (always positive)</span>
+              ${this._entitySelectRow(this._t('editor.sensor_battery_charge', 'Battery Charge Power'), 'entities.battery_charge_power', powerIds('entities.battery_charge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_discharge', 'Battery Discharge Power'), 'entities.battery_discharge_power', powerIds('entities.battery_discharge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${(cfg.entities?.battery_charge_power || cfg.entities?.battery_discharge_power) ? `<span class="note">battery_invert not needed when using separate charge/discharge sensors</span>` : ''}
+              <hr class="group-divider">
+              <span class="group-label">State of charge</span>
+              ${this._entitySelectRow(this._t('editor.sensor_battery_level', 'Battery Level %'), 'entities.battery_level', pctIds('entities.battery_level'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+            </div>
+          </div>
+
+          <!-- ⑥ Load -->
+          <div class="block">
+            <h4>🏠 Home / Load</h4>
+            <div class="grid">
+              ${this._entitySelectRow(this._t('editor.sensor_load', 'Load Power'), 'entities.load_power', powerIds('entities.load_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+            </div>
+          </div>
+
+          <!-- ⑦ EV 1 -->
+          <div class="block">
+            <h4>🚗 EV 1</h4>
+            <div class="grid">
+              ${this._entitySelectRow(this._t('editor.sensor_ev_power', 'EV Power'), 'entities.ev_power', powerIds('entities.ev_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev_battery', 'EV Battery %'), 'entities.ev_battery', pctIds('entities.ev_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev_switch', 'EV Charge Switch'), 'entities.ev_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
+              ${this._entitySelectRow('EV 1 Presence', 'entities.ev_presence', presenceIds, '-- select presence entity --')}
+            </div>
+          </div>
+
+          <!-- ⑧ EV 2 -->
+          <div class="block">
+            <h4>🚗 EV 2</h4>
+            <div class="grid">
+              ${this._entitySelectRow(this._t('editor.sensor_ev2_power', 'EV 2 Power'), 'entities.ev2_power', powerIds('entities.ev2_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev2_battery', 'EV 2 Battery %'), 'entities.ev2_battery', pctIds('entities.ev2_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev2_switch', 'EV 2 Charge Switch'), 'entities.ev2_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
+              ${this._entitySelectRow('EV 2 Presence', 'entities.ev2_presence', presenceIds, '-- select presence entity --')}
+            </div>
+          </div>
+
+          <!-- ⑨ System -->
+          <div class="block">
+            <h4>🌤 System</h4>
+            <div class="grid">
+              ${this._entitySelectRow(this._t('editor.sensor_weather', 'Weather Entity'), 'entities.weather', weatherIds, this._t('editor.placeholder_weather', '-- select weather --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_sun', 'Sun Entity'), 'entities.sun', sunIds, this._t('editor.placeholder_sun', '-- select sun --'))}
+            </div>
+            <div class="hint">${this._t('editor.hint_entities', 'Dropdowns filtered by unit / device class.')}</div>
+          </div>
+
+          <!-- ⑩ Thresholds -->
+          <div class="block">
+            <h4>⚙️ Thresholds</h4>
+            <div class="grid">
               <label>${this._t('editor.field_solar_threshold', 'Solar threshold (W)')}</label>
               <input type="number" data-path="thresholds.solar_min_w" value="${safeNum(cfg.thresholds?.solar_min_w, 50)}">
               <label>${this._t('editor.field_grid_threshold', 'Grid threshold (W)')}</label>
@@ -3570,106 +3730,86 @@
             </div>
           </div>
 
+          <!-- ⑪ Labels -->
           <div class="block">
-            <h4>${this._t('editor.section_sensors', 'Sensors')}</h4>
+            <h4>🏷 Labels</h4>
             <div class="grid">
-              ${this._entitySelectRow(this._t('editor.sensor_solar', 'Solar Power'), 'entities.solar_power', powerIds('entities.solar_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', powerIds('entities.roof_a_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', voltIds('entities.roof_a_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', ampIds('entities.roof_a_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', powerIds('entities.roof_b_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', voltIds('entities.roof_b_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', ampIds('entities.roof_b_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_grid', 'Grid Power'), 'entities.grid_power', powerIds('entities.grid_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_grid_import', 'Grid Import Power'), 'entities.grid_import_power', powerIds('entities.grid_import_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_grid_export', 'Grid Export Power'), 'entities.grid_export_power', powerIds('entities.grid_export_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery', 'Battery Power'), 'entities.battery_power', powerIds('entities.battery_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_charge', 'Battery Charge Power'), 'entities.battery_charge_power', powerIds('entities.battery_charge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_discharge', 'Battery Discharge Power'), 'entities.battery_discharge_power', powerIds('entities.battery_discharge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_load', 'Load Power'), 'entities.load_power', powerIds('entities.load_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_level', 'Battery Level %'), 'entities.battery_level', pctIds('entities.battery_level'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev_power', 'EV Power'), 'entities.ev_power', powerIds('entities.ev_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev_battery', 'EV Battery %'), 'entities.ev_battery', pctIds('entities.ev_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev_switch', 'EV Charge Switch'), 'entities.ev_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
-              ${this._entitySelectRow('EV 1 Presence', 'entities.ev_presence', presenceIds, '-- select presence entity --')}
-              ${this._entitySelectRow(this._t('editor.sensor_ev2_power', 'EV 2 Power'), 'entities.ev2_power', powerIds('entities.ev2_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev2_battery', 'EV 2 Battery %'), 'entities.ev2_battery', pctIds('entities.ev2_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev2_switch', 'EV 2 Charge Switch'), 'entities.ev2_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
-              ${this._entitySelectRow('EV 2 Presence', 'entities.ev2_presence', presenceIds, '-- select presence entity --')}
-              ${this._entitySelectRow(this._t('editor.sensor_weather', 'Weather Entity'), 'entities.weather', weatherIds, this._t('editor.placeholder_weather', '-- select weather --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_sun', 'Sun Entity'), 'entities.sun', sunIds, this._t('editor.placeholder_sun', '-- select sun --'))}
+              <label>EV 1 label</label>
+              <input data-path="ev_label" value="${this._escapeHtml(cfg.ev_label || '')}">
+              <label>EV 2 label</label>
+              <input data-path="ev2_label" value="${this._escapeHtml(cfg.ev2_label || '')}">
+              <label>Roof Array A label</label>
+              <input data-path="roof_a_label" value="${this._escapeHtml(cfg.roof_a_label || 'ARRAY A')}">
+              <label>Roof Array B label</label>
+              <input data-path="roof_b_label" value="${this._escapeHtml(cfg.roof_b_label || 'ARRAY B')}">
             </div>
-            <div class="hint">${this._t('editor.hint_entities', 'Clean menu with domain-filtered entities.')}</div>
           </div>
 
+          <!-- ⑫ Background -->
           <div class="block">
-            <h4>${this._t('editor.section_dynamic_bg', 'Dynamic Background')}</h4>
+            <h4>${this._t('editor.section_dynamic_bg', 'Background')}</h4>
             <div class="grid">
+              <label>${this._t('editor.field_background', 'Background URL')}</label>
+              <input data-path="background" value="${cfg.background || ''}">
+              <label>${this._t('editor.field_background_base', 'Background Assets Base (auto)')}</label>
+              <input data-path="background_asset_base" value="${cfg.background_asset_base || '/local/community/tesla-style-energy-flow/backgrounds'}">
               <div class="row">
-                <label>${this._t('editor.field_dynamic_bg', 'Enable dynamic')}</label>
+                <label>${this._t('editor.field_dynamic_bg', 'Enable dynamic background')}</label>
                 <input type="checkbox" data-path="dynamic_background" ${cfg.dynamic_background ? 'checked' : ''}>
               </div>
-              <label>background_map.default</label>
-              <input data-path="background_map.default" value="${b.default || ''}">
-              <label>background_map.day_default</label>
-              <input data-path="background_map.day_default" value="${b.day_default || ''}">
-              <label>background_map.night_default</label>
-              <input data-path="background_map.night_default" value="${b.night_default || ''}">
-              <label>background_map.morning_default</label>
-              <input data-path="background_map.morning_default" value="${b.morning_default || ''}">
-              <label>background_map.afternoon_default</label>
-              <input data-path="background_map.afternoon_default" value="${b.afternoon_default || ''}">
-              <label>background_map.evening_default</label>
-              <input data-path="background_map.evening_default" value="${b.evening_default || ''}">
-              <label>background_map.day_clear</label>
-              <input data-path="background_map.day_clear" value="${b.day_clear || ''}">
-              <label>background_map.day_cloudy</label>
-              <input data-path="background_map.day_cloudy" value="${b.day_cloudy || ''}">
-              <label>background_map.day_rain</label>
-              <input data-path="background_map.day_rain" value="${b.day_rain || ''}">
-              <label>background_map.night_clear</label>
-              <input data-path="background_map.night_clear" value="${b.night_clear || ''}">
-              <label>background_map.night_cloudy</label>
-              <input data-path="background_map.night_cloudy" value="${b.night_cloudy || ''}">
-              <label>background_map.night_rain</label>
-              <input data-path="background_map.night_rain" value="${b.night_rain || ''}">
-              <label>background_map.day_clear_idle</label>
-              <input data-path="background_map.day_clear_idle" value="${b.day_clear_idle || ''}">
-              <label>background_map.day_clear_charging</label>
-              <input data-path="background_map.day_clear_charging" value="${b.day_clear_charging || ''}">
-              <label>background_map.morning_clear_idle</label>
-              <input data-path="background_map.morning_clear_idle" value="${b.morning_clear_idle || ''}">
-              <label>background_map.morning_clear_charging</label>
-              <input data-path="background_map.morning_clear_charging" value="${b.morning_clear_charging || ''}">
-              <label>background_map.afternoon_clear_idle</label>
-              <input data-path="background_map.afternoon_clear_idle" value="${b.afternoon_clear_idle || ''}">
-              <label>background_map.afternoon_clear_charging</label>
-              <input data-path="background_map.afternoon_clear_charging" value="${b.afternoon_clear_charging || ''}">
-              <label>background_map.evening_clear_idle</label>
-              <input data-path="background_map.evening_clear_idle" value="${b.evening_clear_idle || ''}">
-              <label>background_map.evening_clear_charging</label>
-              <input data-path="background_map.evening_clear_charging" value="${b.evening_clear_charging || ''}">
-              <label>background_map.night_clear_idle</label>
-              <input data-path="background_map.night_clear_idle" value="${b.night_clear_idle || ''}">
-              <label>background_map.night_clear_charging</label>
-              <input data-path="background_map.night_clear_charging" value="${b.night_clear_charging || ''}">
+              <details class="collapsible">
+                <summary>Dynamic background map URLs (${Object.values(b).filter(Boolean).length} configured)</summary>
+                <div class="grid">
+                  <label>background_map.default</label>
+                  <input data-path="background_map.default" value="${b.default || ''}">
+                  <label>background_map.day_default</label>
+                  <input data-path="background_map.day_default" value="${b.day_default || ''}">
+                  <label>background_map.night_default</label>
+                  <input data-path="background_map.night_default" value="${b.night_default || ''}">
+                  <label>background_map.morning_default</label>
+                  <input data-path="background_map.morning_default" value="${b.morning_default || ''}">
+                  <label>background_map.afternoon_default</label>
+                  <input data-path="background_map.afternoon_default" value="${b.afternoon_default || ''}">
+                  <label>background_map.evening_default</label>
+                  <input data-path="background_map.evening_default" value="${b.evening_default || ''}">
+                  <label>background_map.day_clear</label>
+                  <input data-path="background_map.day_clear" value="${b.day_clear || ''}">
+                  <label>background_map.day_cloudy</label>
+                  <input data-path="background_map.day_cloudy" value="${b.day_cloudy || ''}">
+                  <label>background_map.day_rain</label>
+                  <input data-path="background_map.day_rain" value="${b.day_rain || ''}">
+                  <label>background_map.night_clear</label>
+                  <input data-path="background_map.night_clear" value="${b.night_clear || ''}">
+                  <label>background_map.night_cloudy</label>
+                  <input data-path="background_map.night_cloudy" value="${b.night_cloudy || ''}">
+                  <label>background_map.night_rain</label>
+                  <input data-path="background_map.night_rain" value="${b.night_rain || ''}">
+                  <label>background_map.day_clear_idle</label>
+                  <input data-path="background_map.day_clear_idle" value="${b.day_clear_idle || ''}">
+                  <label>background_map.day_clear_charging</label>
+                  <input data-path="background_map.day_clear_charging" value="${b.day_clear_charging || ''}">
+                  <label>background_map.morning_clear_idle</label>
+                  <input data-path="background_map.morning_clear_idle" value="${b.morning_clear_idle || ''}">
+                  <label>background_map.morning_clear_charging</label>
+                  <input data-path="background_map.morning_clear_charging" value="${b.morning_clear_charging || ''}">
+                  <label>background_map.afternoon_clear_idle</label>
+                  <input data-path="background_map.afternoon_clear_idle" value="${b.afternoon_clear_idle || ''}">
+                  <label>background_map.afternoon_clear_charging</label>
+                  <input data-path="background_map.afternoon_clear_charging" value="${b.afternoon_clear_charging || ''}">
+                  <label>background_map.evening_clear_idle</label>
+                  <input data-path="background_map.evening_clear_idle" value="${b.evening_clear_idle || ''}">
+                  <label>background_map.evening_clear_charging</label>
+                  <input data-path="background_map.evening_clear_charging" value="${b.evening_clear_charging || ''}">
+                  <label>background_map.night_clear_idle</label>
+                  <input data-path="background_map.night_clear_idle" value="${b.night_clear_idle || ''}">
+                  <label>background_map.night_clear_charging</label>
+                  <input data-path="background_map.night_clear_charging" value="${b.night_clear_charging || ''}">
+                </div>
+              </details>
             </div>
             <div class="hint">${this._t('editor.hint_bg_lookup', 'Lookup priority: period+weather+charging -> period+weather -> period_default -> default -> background.')}</div>
           </div>
 
-          <div class="block">
-            <h4>${this._t('editor.section_scene_positions', 'Scene positions')}</h4>
-            <div class="grid">
-              <div class="position-actions">
-                <button type="button" class="position-open-button" data-open-position-editor>${this._t('editor.position_open_button', 'Edit visually')}</button>
-              </div>
-              <details class="position-json-details">
-                <summary>scene_component_map JSON</summary>
-                <textarea class="positions-json" data-json-path="scene_component_map" data-commit="change" spellcheck="false">${this._escapeHtml(this._jsonString('scene_component_map'))}</textarea>
-              </details>
-            </div>
-            <div class="hint">${this._t('editor.position_hint', 'Battery percent follows the battery kW value automatically. Path geometry stays in YAML/JSON.')}</div>
-          </div>
           ${this._positionEditorModal()}
         </div>
       `;

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -3189,15 +3189,13 @@
       const presenceIds = this._entityIdsByDomains(['binary_sensor', 'device_tracker', 'person', 'input_boolean']);
       const weatherIds = this._entityIdsByDomain('weather');
       const sunIds = this._entityIdsByDomain('sun');
-      // Filtered lists for common field types — reduces long dropdowns to plausible matches.
       const cfg = this._config;
+      const b = cfg.background_map || {};
+      // Filtered lists for common field types — reduces long dropdowns to plausible matches.
       const powerIds = (path) => this._sensorIdsByUnitOrClass(['W', 'kW'], ['power'], String(this._getByPath(path) || ''));
       const pctIds = (path) => this._sensorIdsByUnitOrClass(['%'], ['battery'], String(this._getByPath(path) || ''));
       const voltIds = (path) => this._sensorIdsByUnitOrClass(['V'], ['voltage'], String(this._getByPath(path) || ''));
       const ampIds = (path) => this._sensorIdsByUnitOrClass(['A'], ['current'], String(this._getByPath(path) || ''));
-
-      const cfg = this._config;
-      const b = cfg.background_map || {};
 
       this.shadowRoot.innerHTML = `
         <style>

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -76,6 +76,8 @@
         section_sensors: 'Sensori',
         sensor_solar: 'Solar Power',
         sensor_grid: 'Grid Power',
+        sensor_grid_import: 'Potenza Importazione Rete',
+        sensor_grid_export: 'Potenza Esportazione Rete',
         sensor_battery: 'Battery Power',
         sensor_battery_charge: 'Potenza Carica Batteria',
         sensor_battery_discharge: 'Potenza Scarica Batteria',
@@ -154,6 +156,8 @@
         section_sensors: 'Sensors',
         sensor_solar: 'Solar Power',
         sensor_grid: 'Grid Power',
+        sensor_grid_import: 'Grid Import Power',
+        sensor_grid_export: 'Grid Export Power',
         sensor_battery: 'Battery Power',
         sensor_battery_charge: 'Battery Charge Power',
         sensor_battery_discharge: 'Battery Discharge Power',
@@ -232,6 +236,8 @@
         section_sensors: 'Sensores',
         sensor_solar: 'Potencia Solar',
         sensor_grid: 'Potencia Red',
+        sensor_grid_import: 'Potencia Importacion Red',
+        sensor_grid_export: 'Potencia Exportacion Red',
         sensor_battery: 'Potencia Bateria',
         sensor_battery_charge: 'Potencia Carga Bateria',
         sensor_battery_discharge: 'Potencia Descarga Bateria',
@@ -310,6 +316,8 @@
         section_sensors: 'Capteurs',
         sensor_solar: 'Puissance Solaire',
         sensor_grid: 'Puissance Reseau',
+        sensor_grid_import: 'Puissance Importation Reseau',
+        sensor_grid_export: 'Puissance Exportation Reseau',
         sensor_battery: 'Puissance Batterie',
         sensor_battery_charge: 'Puissance Charge Batterie',
         sensor_battery_discharge: 'Puissance Decharge Batterie',
@@ -388,6 +396,8 @@
         section_sensors: 'Sensoren',
         sensor_solar: 'Solarleistung',
         sensor_grid: 'Netzleistung',
+        sensor_grid_import: 'Netzbezug (Einspeisung)',
+        sensor_grid_export: 'Netzeinspeisung (Export)',
         sensor_battery: 'Batterieleistung',
         sensor_battery_charge: 'Batterie Ladeleistung',
         sensor_battery_discharge: 'Batterie Entladeleistung',
@@ -1029,6 +1039,8 @@
       roof_b_voltage: '',
       roof_b_current: '',
       grid_power: '',
+      grid_import_power: '',
+      grid_export_power: '',
       battery_power: '',
       battery_charge_power: '',
       battery_discharge_power: '',
@@ -2307,7 +2319,15 @@
 
       const solarPower = toWatt(this._entityState(cfg.entities.solar_power));
       const gridRaw = toWatt(this._entityState(cfg.entities.grid_power));
-      const gridPower = cfg.grid_invert ? -gridRaw : gridRaw;
+      let gridPower = cfg.grid_invert ? -gridRaw : gridRaw;
+      // Separate import/export entities override the combined grid_power sensor.
+      // import entity is always positive (watts coming from grid),
+      // export entity is always positive (watts going to grid).
+      if (cfg.entities.grid_import_power || cfg.entities.grid_export_power) {
+        const importPower = Math.max(0, toWatt(this._entityState(cfg.entities.grid_import_power)));
+        const exportPower = Math.max(0, toWatt(this._entityState(cfg.entities.grid_export_power)));
+        gridPower = importPower - exportPower;
+      }
       const roofAPower = toWatt(this._entityState(cfg.entities.roof_a_power));
       const roofAVoltage = safeNum(this._entityState(cfg.entities.roof_a_voltage)?.state, 0);
       const roofACurrent = safeNum(this._entityState(cfg.entities.roof_a_current)?.state, 0);
@@ -2638,6 +2658,24 @@
       const domainSet = new Set(Array.isArray(domains) ? domains : []);
       return Object.keys(this._hass.states)
         .filter((id) => domainSet.has(id.split('.')[0]))
+        .sort((a, b) => a.localeCompare(b));
+    }
+
+    // Returns sensor entity IDs filtered by unit_of_measurement and/or device_class.
+    // Always includes the currently configured value even if it doesn't match.
+    _sensorIdsByUnitOrClass(units = [], deviceClasses = [], currentValue = '') {
+      if (!this._hass) return [];
+      const unitSet = new Set(units);
+      const classSet = new Set(deviceClasses);
+      return Object.keys(this._hass.states)
+        .filter((id) => {
+          if (!id.startsWith('sensor.')) return false;
+          if (id === currentValue) return true;
+          const attrs = this._hass.states[id]?.attributes || {};
+          if (unitSet.size > 0 && unitSet.has(attrs.unit_of_measurement)) return true;
+          if (classSet.size > 0 && classSet.has(attrs.device_class)) return true;
+          return false;
+        })
         .sort((a, b) => a.localeCompare(b));
     }
 
@@ -3149,6 +3187,12 @@
       const presenceIds = this._entityIdsByDomains(['binary_sensor', 'device_tracker', 'person', 'input_boolean']);
       const weatherIds = this._entityIdsByDomain('weather');
       const sunIds = this._entityIdsByDomain('sun');
+      // Filtered lists for common field types — reduces long dropdowns to plausible matches.
+      const cfg = this._config;
+      const powerIds = (path) => this._sensorIdsByUnitOrClass(['W', 'kW'], ['power'], String(this._getByPath(path) || ''));
+      const pctIds = (path) => this._sensorIdsByUnitOrClass(['%'], ['battery'], String(this._getByPath(path) || ''));
+      const voltIds = (path) => this._sensorIdsByUnitOrClass(['V'], ['voltage'], String(this._getByPath(path) || ''));
+      const ampIds = (path) => this._sensorIdsByUnitOrClass(['A'], ['current'], String(this._getByPath(path) || ''));
 
       const cfg = this._config;
       const b = cfg.background_map || {};
@@ -3529,25 +3573,27 @@
           <div class="block">
             <h4>${this._t('editor.section_sensors', 'Sensors')}</h4>
             <div class="grid">
-              ${this._entitySelectRow(this._t('editor.sensor_solar', 'Solar Power'), 'entities.solar_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_grid', 'Grid Power'), 'entities.grid_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery', 'Battery Power'), 'entities.battery_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_charge', 'Battery Charge Power'), 'entities.battery_charge_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_discharge', 'Battery Discharge Power'), 'entities.battery_discharge_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_load', 'Load Power'), 'entities.load_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_battery_level', 'Battery Level %'), 'entities.battery_level', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev_power', 'EV Power'), 'entities.ev_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev_battery', 'EV Battery %'), 'entities.ev_battery', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_solar', 'Solar Power'), 'entities.solar_power', powerIds('entities.solar_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', powerIds('entities.roof_a_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', voltIds('entities.roof_a_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', ampIds('entities.roof_a_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', powerIds('entities.roof_b_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', voltIds('entities.roof_b_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', ampIds('entities.roof_b_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_grid', 'Grid Power'), 'entities.grid_power', powerIds('entities.grid_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_grid_import', 'Grid Import Power'), 'entities.grid_import_power', powerIds('entities.grid_import_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_grid_export', 'Grid Export Power'), 'entities.grid_export_power', powerIds('entities.grid_export_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery', 'Battery Power'), 'entities.battery_power', powerIds('entities.battery_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_charge', 'Battery Charge Power'), 'entities.battery_charge_power', powerIds('entities.battery_charge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_discharge', 'Battery Discharge Power'), 'entities.battery_discharge_power', powerIds('entities.battery_discharge_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_load', 'Load Power'), 'entities.load_power', powerIds('entities.load_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_level', 'Battery Level %'), 'entities.battery_level', pctIds('entities.battery_level'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev_power', 'EV Power'), 'entities.ev_power', powerIds('entities.ev_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev_battery', 'EV Battery %'), 'entities.ev_battery', pctIds('entities.ev_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_ev_switch', 'EV Charge Switch'), 'entities.ev_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
               ${this._entitySelectRow('EV 1 Presence', 'entities.ev_presence', presenceIds, '-- select presence entity --')}
-              ${this._entitySelectRow(this._t('editor.sensor_ev2_power', 'EV 2 Power'), 'entities.ev2_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              ${this._entitySelectRow(this._t('editor.sensor_ev2_battery', 'EV 2 Battery %'), 'entities.ev2_battery', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev2_power', 'EV 2 Power'), 'entities.ev2_power', powerIds('entities.ev2_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_ev2_battery', 'EV 2 Battery %'), 'entities.ev2_battery', pctIds('entities.ev2_battery'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_ev2_switch', 'EV 2 Charge Switch'), 'entities.ev2_charge_switch', switchIds, this._t('editor.placeholder_switch', '-- select switch --'))}
               ${this._entitySelectRow('EV 2 Presence', 'entities.ev2_presence', presenceIds, '-- select presence entity --')}
               ${this._entitySelectRow(this._t('editor.sensor_weather', 'Weather Entity'), 'entities.weather', weatherIds, this._t('editor.placeholder_weather', '-- select weather --'))}

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -77,6 +77,8 @@
         sensor_solar: 'Solar Power',
         sensor_grid: 'Grid Power',
         sensor_battery: 'Battery Power',
+        sensor_battery_charge: 'Potenza Carica Batteria',
+        sensor_battery_discharge: 'Potenza Scarica Batteria',
         sensor_load: 'Load Power',
         sensor_battery_level: 'Battery Level %',
         sensor_ev_power: 'EV Power',
@@ -153,6 +155,8 @@
         sensor_solar: 'Solar Power',
         sensor_grid: 'Grid Power',
         sensor_battery: 'Battery Power',
+        sensor_battery_charge: 'Battery Charge Power',
+        sensor_battery_discharge: 'Battery Discharge Power',
         sensor_load: 'Load Power',
         sensor_battery_level: 'Battery Level %',
         sensor_ev_power: 'EV Power',
@@ -229,6 +233,8 @@
         sensor_solar: 'Potencia Solar',
         sensor_grid: 'Potencia Red',
         sensor_battery: 'Potencia Bateria',
+        sensor_battery_charge: 'Potencia Carga Bateria',
+        sensor_battery_discharge: 'Potencia Descarga Bateria',
         sensor_load: 'Potencia Casa',
         sensor_battery_level: 'Nivel Bateria %',
         sensor_ev_power: 'Potencia EV',
@@ -305,6 +311,8 @@
         sensor_solar: 'Puissance Solaire',
         sensor_grid: 'Puissance Reseau',
         sensor_battery: 'Puissance Batterie',
+        sensor_battery_charge: 'Puissance Charge Batterie',
+        sensor_battery_discharge: 'Puissance Decharge Batterie',
         sensor_load: 'Puissance Maison',
         sensor_battery_level: 'Niveau Batterie %',
         sensor_ev_power: 'Puissance EV',
@@ -381,6 +389,8 @@
         sensor_solar: 'Solarleistung',
         sensor_grid: 'Netzleistung',
         sensor_battery: 'Batterieleistung',
+        sensor_battery_charge: 'Batterie Ladeleistung',
+        sensor_battery_discharge: 'Batterie Entladeleistung',
         sensor_load: 'Hausverbrauch',
         sensor_battery_level: 'Batteriestand %',
         sensor_ev_power: 'EV Leistung',
@@ -1020,6 +1030,8 @@
       roof_b_current: '',
       grid_power: '',
       battery_power: '',
+      battery_charge_power: '',
+      battery_discharge_power: '',
       load_power: '',
       battery_level: '',
       ev_power: '',
@@ -2304,6 +2316,14 @@
       const roofBCurrent = safeNum(this._entityState(cfg.entities.roof_b_current)?.state, 0);
       let batteryPower = toWatt(this._entityState(cfg.entities.battery_power));
       if (cfg.battery_invert) batteryPower *= -1;
+      // Separate charge/discharge entities override the combined battery_power sensor.
+      // charge entity is always positive (watts going into battery),
+      // discharge entity is always positive (watts coming out of battery).
+      if (cfg.entities.battery_charge_power || cfg.entities.battery_discharge_power) {
+        const chargePower = Math.max(0, toWatt(this._entityState(cfg.entities.battery_charge_power)));
+        const dischargePower = Math.max(0, toWatt(this._entityState(cfg.entities.battery_discharge_power)));
+        batteryPower = chargePower - dischargePower;
+      }
       const loadPower = toWatt(this._entityState(cfg.entities.load_power));
       const batteryLevel = toPct(this._entityState(cfg.entities.battery_level), 0);
       const batteryConfigured = !!(cfg.entities.battery_power || cfg.entities.battery_level);
@@ -3518,6 +3538,8 @@
               ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_grid', 'Grid Power'), 'entities.grid_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_battery', 'Battery Power'), 'entities.battery_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_charge', 'Battery Charge Power'), 'entities.battery_charge_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              ${this._entitySelectRow(this._t('editor.sensor_battery_discharge', 'Battery Discharge Power'), 'entities.battery_discharge_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_load', 'Load Power'), 'entities.load_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_battery_level', 'Battery Level %'), 'entities.battery_level', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}
               ${this._entitySelectRow(this._t('editor.sensor_ev_power', 'EV Power'), 'entities.ev_power', sensorIds, this._t('editor.placeholder_sensor', '-- select sensor --'))}

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -3184,6 +3184,14 @@
     }
 
     _render() {
+      // Preserve open state of <details> elements across re-renders.
+      // HA calls set hass() on every entity update which triggers _render(),
+      // replacing innerHTML and collapsing all <details> nodes.
+      const openDetailKeys = new Set();
+      this.shadowRoot.querySelectorAll('details[data-key]').forEach((d) => {
+        if (d.open) openDetailKeys.add(d.dataset.key);
+      });
+
       const sensorIds = this._entityIdsByDomain('sensor');
       const switchIds = this._entityIdsByDomain('switch');
       const presenceIds = this._entityIdsByDomains(['binary_sensor', 'device_tracker', 'person', 'input_boolean']);
@@ -3607,7 +3615,7 @@
               <button type="button" class="visual-editor-btn position-open-button" data-open-position-editor>${this._t('editor.position_open_button', 'Edit visually')}</button>
               <span class="hint">${this._t('editor.position_hint', 'Battery percent follows the battery kW value automatically. Path geometry stays in YAML/JSON.')}</span>
             </div>
-            <details class="collapsible position-json-details" style="margin-top:8px">
+            <details class="collapsible position-json-details" data-key="scene-json" style="margin-top:8px">
               <summary>scene_component_map JSON</summary>
               <textarea class="positions-json" data-json-path="scene_component_map" data-commit="change" spellcheck="false">${this._escapeHtml(this._jsonString('scene_component_map'))}</textarea>
             </details>
@@ -3618,18 +3626,18 @@
             <h4>☀️ Solar</h4>
             <div class="grid">
               ${this._entitySelectRow(this._t('editor.sensor_solar', 'Solar Power'), 'entities.solar_power', powerIds('entities.solar_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-              <details class="collapsible">
-                <summary>Roof Array A / B (optional)</summary>
-                <div class="grid">
-                  ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', powerIds('entities.roof_a_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                  ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', voltIds('entities.roof_a_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                  ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', ampIds('entities.roof_a_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                  ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', powerIds('entities.roof_b_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                  ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', voltIds('entities.roof_b_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                  ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', ampIds('entities.roof_b_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
-                </div>
-              </details>
             </div>
+            <details class="collapsible" data-key="roof-arrays" style="margin-top:8px">
+              <summary>Roof Array A / B (optional)</summary>
+              <div class="grid" style="margin-top:6px">
+                ${this._entitySelectRow('Roof Array A Power', 'entities.roof_a_power', powerIds('entities.roof_a_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                ${this._entitySelectRow('Roof Array A Voltage', 'entities.roof_a_voltage', voltIds('entities.roof_a_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                ${this._entitySelectRow('Roof Array A Current', 'entities.roof_a_current', ampIds('entities.roof_a_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                ${this._entitySelectRow('Roof Array B Power', 'entities.roof_b_power', powerIds('entities.roof_b_power'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                ${this._entitySelectRow('Roof Array B Voltage', 'entities.roof_b_voltage', voltIds('entities.roof_b_voltage'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+                ${this._entitySelectRow('Roof Array B Current', 'entities.roof_b_current', ampIds('entities.roof_b_current'), this._t('editor.placeholder_sensor', '-- select sensor --'))}
+              </div>
+            </details>
           </div>
 
           <!-- ④ Grid sensors -->
@@ -3755,7 +3763,7 @@
                 <label>${this._t('editor.field_dynamic_bg', 'Enable dynamic background')}</label>
                 <input type="checkbox" data-path="dynamic_background" ${cfg.dynamic_background ? 'checked' : ''}>
               </div>
-              <details class="collapsible">
+              <details class="collapsible" data-key="bg-map">
                 <summary>Dynamic background map URLs (${Object.values(b).filter(Boolean).length} configured)</summary>
                 <div class="grid">
                   <label>background_map.default</label>
@@ -3811,6 +3819,11 @@
           ${this._positionEditorModal()}
         </div>
       `;
+
+      // Restore previously open <details> after innerHTML replacement.
+      this.shadowRoot.querySelectorAll('details[data-key]').forEach((d) => {
+        if (openDetailKeys.has(d.dataset.key)) d.open = true;
+      });
 
       this.shadowRoot.querySelectorAll('button[data-open-position-editor]').forEach((button) => {
         button.addEventListener('click', () => {

--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -2507,9 +2507,18 @@
       }
 
       this._activatePath('line-solar-load', 'flow-solar', solarToLoad, solarMin);
-      this._activatePath('line-grid-load', 'flow-broken', gridImportVisual, gridMin);
-      this._activatePath('line-grid-load', 'flow-green', batteryToGrid, Math.max(1, Math.min(gridMin, batteryMin)), true);
-      this._activatePath('line-battery-load', 'flow-green', Math.max(battToLoad, batteryToGrid), Math.max(1, Math.min(gridMin, batteryMin)));
+      // line-grid-load: forward = grid imports to home junction; reverse = battery exports via junction to grid.
+      // Only activate one direction at a time to avoid the two calls overwriting each other's flow-reverse flag.
+      if (batteryToGrid >= Math.max(1, Math.min(gridMin, batteryMin)) && gridImportVisual < gridMin) {
+        // Battery is exporting to grid and grid is NOT simultaneously importing above threshold:
+        // show battery→junction→grid (reverse on this path)
+        this._activatePath('line-grid-load', 'flow-green', batteryToGrid, Math.max(1, Math.min(gridMin, batteryMin)), true);
+      } else {
+        // Normal grid import (or both: grid import dominates, battery export is low/zero)
+        this._activatePath('line-grid-load', 'flow-broken', gridImportVisual, gridMin);
+      }
+      const battLoadThreshold = Math.max(1, Math.min(gridMin, batteryMin));
+      this._activatePath('line-battery-load', 'flow-green', Math.max(battToLoad, batteryToGrid), battLoadThreshold);
 
       const homeTotal = solarToLoad + battToLoad + gridToLoadVisual;
       const homeCls = this._dominantFlowClass(solarToLoad, battToLoad, gridToLoadVisual, 'flow-solar');
@@ -2517,7 +2526,8 @@
 
       this._activatePath('line-solar-battery', 'flow-solar', solarToBattery, batteryMin);
       this._activatePath('line-grid-battery', 'flow-broken', gridToBattery, batteryMin);
-      this._activatePath('line-solar-grid', 'flow-green', gridExportVisual, Math.max(1, gridMin));
+      // line-solar-grid: only solar export; battery→grid is shown via line-battery-load + line-grid-load (reverse)
+      this._activatePath('line-solar-grid', 'flow-green', solarExport, Math.max(1, gridMin));
 
       const evTotal = solarToEv + battToEv + gridToEv;
       const evCls = this._dominantFlowClass(solarToEv, battToEv, gridToEv, 'flow-green');


### PR DESCRIPTION
## Summary

This PR bundles several improvements developed and tested in [Optic00/tesla-style-energy-flow](https://github.com/Optic00/tesla-style-energy-flow). Happy to split into separate PRs if that's easier to review.

---

## 1. fix: grid → battery flow animation

**Relates to #4** *(reporter is testing with their SolarEdge setup — leaving the issue open until confirmation)*

The `line-grid-battery` animation was only shown when `solarToBattery < batteryMin`, which meant it was suppressed whenever solar was also charging the battery above the threshold — or when both values happened to be exactly equal.

Removed the condition; `gridToBattery` is now always computed from whatever battery charge capacity remains after solar allocation. The existing `_activatePath` already enforces the minimum-watt guard.

---

## 2. feat: separate battery charge / discharge power entities

Users with inverters that expose separate charge and discharge sensors (Victron, Fronius, SolarEdge, Sungrow, …) previously had to build a template sensor. Now supported natively:

```yaml
entities:
  battery_charge_power: sensor.battery_charge_w    # always >= 0
  battery_discharge_power: sensor.battery_discharge_w  # always >= 0
```

- Both override `battery_power` when either is set
- `battery_invert` is ignored when separate entities are used
- All existing configs with `battery_power` are fully unaffected

---

## 3. feat: separate grid import / export power entities

Same pattern for grid — useful for SMA SHM 2.0, Victron, Fronius and similar systems:

```yaml
entities:
  grid_import_power: sensor.grid_import_w    # always >= 0
  grid_export_power: sensor.grid_export_w    # always >= 0
```

- Overrides `grid_power` + `grid_invert` when either is set
- All existing configs unaffected

---

## 4. feat: smart entity filtering in editor dropdowns

Entity dropdowns now show only plausible matches per field type instead of the full sensor list:

| Field type | Filter |
|---|---|
| Power (solar, grid, battery, load, EV) | unit W or kW, or device_class power |
| State of charge (battery %, EV %) | unit %, or device_class battery |
| Voltage | unit V, or device_class voltage |
| Current | unit A, or device_class current |

Currently selected entity always appears even if outside the filter. Dropdown labels now show **Friendly Name · entity.id** instead of the raw entity ID.

---

## 5. refactor: editor UI restructure

The editor was a single block with 25+ unsorted rows. Restructured into logical sections:

- **General** — title, language, display toggles, scale
- **Scene positions** — visual editor button moved to the top (was at the very bottom), JSON in a collapsible `<details>`
- **☀️ Solar** — solar power + Roof Array A/B in collapsible section
- **⚡ Grid** — combined sensor or separate import/export; invert checkbox auto-hidden when separate entities configured
- **🔋 Battery** — combined sensor or separate charge/discharge; invert checkbox auto-hidden; SOC in own sub-section
- **🏠 Home/Load**, **🚗 EV 1**, **🚗 EV 2**, **🌤 System** — each in own block
- **⚙️ Thresholds** — own block (were buried in General)
- **🏷 Labels** — own block
- **Background** — static URL visible, dynamic background map in collapsible `<details>` showing count of configured URLs

Also fixed: `<details>` accordions were collapsing immediately after opening because HA calls `set hass()` on every entity update, triggering a full `innerHTML` replacement. Fixed by saving and restoring `open` state across re-renders using stable `data-key` attributes.

---

## 6. fix: battery→grid and battery+grid→home animations

**Relates to #4**

Two animation bugs addressed:

**a) `line-solar-grid` used total grid export instead of solar-only export**

The solar→grid path was activated with `gridExportVisual` (solar + battery combined), so it lit up even when the battery was the sole exporter — making it look like solar was producing when it wasn't. Fixed: `line-solar-grid` now uses `solarExport` only. Battery→grid is already correctly shown via `line-battery-load` (forward) + `line-grid-load` (reversed).

**b) `line-grid-load` direction conflict when grid imports and battery exports simultaneously**

`_activatePath` was called twice on the same SVG element — once forward (grid import) and once reversed (battery export to grid). If both were above threshold, the second call's `flow-reverse` flag overwrote the first, reversing the grid-import animation. Fixed: only one direction is chosen at a time based on which is dominant.

✅ Battery→grid animation confirmed working (tested locally in HA).
✅ Grid→battery animation confirmed working (grid power flows correctly to battery + junction).
✅ Battery+grid→home simultaneous scenario confirmed working.

---

All changes are backward-compatible. No existing YAML config needs to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
