### PR TITLE
fix: stutter on grid → home flow line (#27)

### DIFF
--- a/dist/tesla-style-energy-flow.js
+++ b/dist/tesla-style-energy-flow.js
@@ -2385,7 +2385,9 @@
             stroke: #ff5d73;
             --flow-glow: rgba(255, 93, 115, 0.7);
             --flow-seg: 40;
-            --flow-gap: 96;
+            /* 40 + 104 = 144, matching the flowStream stroke-dashoffset cycle so the
+               grid/import dashes loop seamlessly instead of jumping every cycle (#27). */
+            --flow-gap: 104;
             --flow-speed: 1.35s;
             --flow-fade: 1.15s;
           }

--- a/tests/visual-polish.test.mjs
+++ b/tests/visual-polish.test.mjs
@@ -366,3 +366,26 @@ assert.match(
   /<rect class="flow-sky-dim" x="0" y="0" width="600" height="260"><\/rect>/,
   'the SVG should include a sky dimming layer so text remains readable on bright backgrounds'
 );
+
+// Regression for #27 "Stutter from grid to home": the flowStream keyframe scrolls
+// stroke-dashoffset by a fixed distance every cycle, so a seamless loop requires the
+// dash period (--flow-seg + --flow-gap) of every flow colour to equal that distance.
+// flow-broken (the grid/import colour) used 40 + 96 = 136 while the offset is 144,
+// producing an 8-unit phase jump once per cycle — a visible stutter on the grid->home line.
+const flowStreamCycle = (() => {
+  const m = source.match(/@keyframes flowStream \{\s*to \{ stroke-dashoffset: -(\d+(?:\.\d+)?)/);
+  assert.ok(m, 'flowStream keyframe should define a stroke-dashoffset scroll distance');
+  return Number(m[1]);
+})();
+
+for (const colour of ['flow-solar', 'flow-green', 'flow-broken']) {
+  const block = source.match(new RegExp(`\\.flow-line\\.active\\.${colour} \\{([\\s\\S]*?)\\}`));
+  assert.ok(block, `${colour} flow-line rule should exist`);
+  const seg = Number(block[1].match(/--flow-seg:\s*(\d+(?:\.\d+)?)/)?.[1]);
+  const gap = Number(block[1].match(/--flow-gap:\s*(\d+(?:\.\d+)?)/)?.[1]);
+  assert.equal(
+    seg + gap,
+    flowStreamCycle,
+    `${colour} dash period (--flow-seg ${seg} + --flow-gap ${gap} = ${seg + gap}) must equal the flowStream scroll distance ${flowStreamCycle} so the dashes loop without stuttering`
+  );
+}


### PR DESCRIPTION
Fixes #27.

## Root cause
The flow lines scroll via `@keyframes flowStream`, which animates `stroke-dashoffset` by **−144** per cycle. For a seamless loop the dash period (`--flow-seg` + `--flow-gap`) of every colour must equal that distance:

| class | seg + gap | sum |
|---|---|---|
| `flow-solar` | 64 + 80 | 144 ✅ |
| `flow-green` | 62 + 82 | 144 ✅ |
| `flow-broken` | 40 + 96 | **136 ❌** |

`flow-broken` is the grid/import colour (`line-grid-load`, and `line-junction-home-load` when the grid dominates). Its 8-unit shortfall made the dashes jump back once per cycle (~1.35 s) — the visible stutter on the grid → home line. Because the other two colours already summed to 144, only the red grid line stuttered, on both Blink (Chrome/macOS) and WebKit (HA iOS app), which matches the report. `smoothing_seconds` only smooths power values, so it could not address this.

## Fix
Set `--flow-gap: 104` so `40 + 104 = 144`. One CSS value; also covers the other `flow-broken` line (`line-grid-battery`). The reverse keyframe scrolls `+144` and stays aligned.

## Test
Added a regression test in `tests/visual-polish.test.mjs` that parses the `flowStream` scroll distance and asserts `--flow-seg + --flow-gap` equals it for every flow colour, so a future mismatch fails CI. Verified RED before the fix (136 ≠ 144) and GREEN after; full suite passes (`node tests/visual-polish.test.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)